### PR TITLE
TOOLS-4033 Add CODEOWNERS validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
 name: CI
-on: 
-  push:
-  workflow_dispatch:
+
+on: push
+
 jobs:
-  shared-workflow:
-    uses: scribd/github-actions-shared-workflows/.github/workflows/shared-workflow.yml@main
-    secrets:
-      github_access_token: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}
+  codeowners:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: GitHub CODEOWNERS Validator
+        uses: mszostok/codeowners-validator@v0.7.1
+        with:
+          checks: "files,duppatterns,syntax"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+name: CI
+on: 
+  push:
+  workflow_dispatch:
+jobs:
+  shared-workflow:
+    uses: scribd/github-actions-shared-workflows/.github/workflows/shared-workflow.yml@main
+    secrets:
+      github_access_token: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}


### PR DESCRIPTION
## Description

This is part of the ITGC initiative ensuring all business-critical repos are compliant. The codeowners-validator must be present to ensure the integrity of the code review process

**UPDATE**: We cannot use the shared workflow since this is a public repository therefore we just call the underlying codeowner validator directly.

## Jira Ticket

https://scribdjira.atlassian.net/browse/TOOLS-4033
